### PR TITLE
chore: allow building without Rust nightly

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -83,8 +83,8 @@ async fn ssh_writer(
             return Err(io::Error::from(io::ErrorKind::ConnectionReset));
         }
     }
-    _ = ssh.eof(channel).await;
-    _ = ssh.close(channel).await;
+    let _ = ssh.eof(channel).await;
+    let _ = ssh.close(channel).await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(destructuring_assignment)]
 #![feature(option_get_or_insert_default)]
 mod config;
 mod handler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(option_get_or_insert_default)]
 mod config;
 mod handler;
 mod logind;

--- a/src/telnet/mod.rs
+++ b/src/telnet/mod.rs
@@ -166,7 +166,9 @@ async fn run_processor<R: AsyncRead + Unpin, H: Handler>(
     loop {
         match read_half.read(&mut buf).await {
             Ok(n) => {
-                (handler, remote) = processor.process(&buf[..n], handler, remote).await?;
+                let (handler_, remote_) = processor.process(&buf[..n], handler, remote).await?;
+                handler = handler_;
+                remote = remote_;
                 if n == 0 {
                     break;
                 }

--- a/src/telnet/mod.rs
+++ b/src/telnet/mod.rs
@@ -78,13 +78,13 @@ fn escape_iov<'a>(data: &'a [u8], skip_single: bool) -> Option<Vec<IoSlice<'a>>>
     let mut last = 0;
     for (i, &b) in data.iter().enumerate() {
         if b == IAC {
-            iov.get_or_insert_default()
+            iov.get_or_insert_with(Default::default)
                 .push(IoSlice::new(&data[last..=i]));
             last = i;
         }
     }
     if iov.is_some() || !skip_single {
-        iov.get_or_insert_default()
+        iov.get_or_insert_with(Default::default)
             .push(IoSlice::new(&data[last..]));
     }
     iov


### PR DESCRIPTION
`#![feature()]` attributes are available only with Rust nightly. This pull request eliminates the use of the following `#![feature()]` attributes:
- `#![feature(destructuring_assignment)]`
- `#![feature(option_get_or_insert_default)]`

This makes `bbs-sshd` able to be built with Rust stable.